### PR TITLE
fix possible concurrency bug

### DIFF
--- a/Assets/Scripts/Slime/Simulation.cs
+++ b/Assets/Scripts/Slime/Simulation.cs
@@ -139,6 +139,8 @@ public class Simulation : MonoBehaviour
 
 		// Assign textures
 		compute.SetTexture(updateKernel, "TrailMap", trailMap);
+		compute.SetTexture(updateKernel, "DiffusedTrailMap", diffusedTrailMap);
+
 		compute.SetTexture(diffuseMapKernel, "TrailMap", trailMap);
 		compute.SetTexture(diffuseMapKernel, "DiffusedTrailMap", diffusedTrailMap);
 

--- a/Assets/Scripts/Slime/SlimeSim.compute
+++ b/Assets/Scripts/Slime/SlimeSim.compute
@@ -23,6 +23,7 @@ RWStructuredBuffer<Agent> agents;
 uint numAgents;
 
 RWTexture2D<float4> TrailMap;
+RWTexture2D<float4> DiffusedTrailMap;
 int width;
 int height;
 
@@ -65,7 +66,7 @@ float sense(Agent agent, SpeciesSettings settings, float sensorAngleOffset) {
 		for (int offsetY = -settings.sensorSize; offsetY <= settings.sensorSize; offsetY ++) {
 			int sampleX = min(width - 1, max(0, sensorCentreX + offsetX));
 			int sampleY = min(height - 1, max(0, sensorCentreY + offsetY));
-			sum += dot(senseWeight, TrailMap[int2(sampleX,sampleY)]);
+			sum += dot(senseWeight, DiffusedTrailMap[int2(sampleX,sampleY)]);
 		}
 	}
 
@@ -128,7 +129,7 @@ void Update (uint3 id : SV_DispatchThreadID)
 		agents[id.x].angle = randomAngle;
 	}
 	else {
-		float4 oldTrail = TrailMap[int2(newPos)];
+		float4 oldTrail = DiffusedTrailMap[int2(newPos)];
 		TrailMap[int2(newPos)] = min(1, oldTrail + agent.speciesMask * trailWeight * deltaTime);
 	}
 	
@@ -139,7 +140,6 @@ void Update (uint3 id : SV_DispatchThreadID)
 
 float decayRate;
 float diffuseRate;
-RWTexture2D<float4> DiffusedTrailMap;
 
 [numthreads(8,8,1)]
 void Diffuse (uint3 id : SV_DispatchThreadID)


### PR DESCRIPTION
Instead of `Update` both reading and writing from `TrailMap`, it now reads from `DiffusedTrailMap` and writes to `TrailMap`. This seems to avoid concurrency issues because it fixes https://github.com/SebLague/Slime-Simulation/issues/2 (at least for me).