### PR TITLE
Update Simulation.cs

### DIFF
--- a/Assets/Scripts/Slime/Simulation.cs
+++ b/Assets/Scripts/Slime/Simulation.cs
@@ -110,7 +110,7 @@ public class Simulation : MonoBehaviour
 
 	}
 
-	void FixedUpdate()
+	void Update()
 	{
 		for (int i = 0; i < settings.stepsPerFrame; i++)
 		{


### PR DESCRIPTION
Running the compile shader code from the update() instead of fixedupdate makes a big performance improvement.